### PR TITLE
Fixed "cannot tree shake icons fonts" when building in release mode

### DIFF
--- a/lib/src/choices_empty.dart
+++ b/lib/src/choices_empty.dart
@@ -14,7 +14,7 @@ class S2ChoicesEmpty extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             Icon(
-              IconData(0xe8b6, fontFamily: 'MaterialIcons'),
+              const IconData(0xe8b6, fontFamily: 'MaterialIcons'),
               color: Color(0x1F000000),
               size: 120.0,
             ),


### PR DESCRIPTION
Just adding a "const" to choices_empty does the trick.